### PR TITLE
Fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,13 +73,13 @@ Jetty HTTP adapter for Luminus
 ;;create a single WS handler
 (http/start
  {:handler http-handler
-  :was-handler ws-handler-a
+  :ws-handler ws-handler-a
   :port 3000})
 
 ;;create multiple WS handlers
 (http/start
  {:handler http-handler
-  :was-handlers [ws-handler-a ws-handler-b]
+  :ws-handlers [ws-handler-a ws-handler-b]
   :port 3000})
 ```
 


### PR DESCRIPTION
So that they match corresponding keys at [https://github.com/luminus-framework/luminus-jetty/blob/master/src/luminus/http_server.clj#L23](https://github.com/luminus-framework/luminus-jetty/blob/master/src/luminus/http_server.clj#L23)

I could reproduce it locally with and without :was-* naming